### PR TITLE
Snort ruleset 2.9.12 needs a zero at the end - the right format is `s…

### DIFF
--- a/ids-update.pl
+++ b/ids-update.pl
@@ -1095,6 +1095,9 @@ sub check_for_updates( $ )
 
   my $Version = `snort -V 2>&1 | grep 'Version'`;
   my ($v) = $Version =~ m/(\d+\.[\d\.]*)/;
+  if ($v eq '2.9.12') {
+    $v = $v . '0';
+  }
   $v =~ s/\.//g if ($v);
   $vrt_v = $v if ($v);
 


### PR DESCRIPTION
…nortrules-snapshot-29120.tar.gz`